### PR TITLE
Plugins page link bug

### DIFF
--- a/includes/class-instant-content-admin-search.php
+++ b/includes/class-instant-content-admin-search.php
@@ -24,7 +24,10 @@ class Instant_Content_Admin_Search extends Instant_Content_Admin {
 		parent::init();
 
 		// Add link from plugins page
-		add_filter( 'plugin_action_links', array( $this, 'plugins_page_link' ) );
+		add_filter(
+			'plugin_action_links_' . Instant_Content::SLUG . '/' . Instant_Content::SLUG . '.php',
+			array( $this, 'plugins_page_link' )
+		);
 	}
 
 	/**


### PR DESCRIPTION
The Search link is appearing on all plugins - not just the Instant Content plugin.

The use of hard-coded plugin directory and main plugin file isn't ideal here, but it works for now. Doesn't seem to be an easy way to grab the main plugin file basename, from inside another plugin file - not without creating a global variable of `plugin_basename( __FILE__ )` inside the main plugin file.
