### PR TITLE
Improve internationalized strings by moving wrapping markup outside

### DIFF
--- a/views/search.php
+++ b/views/search.php
@@ -107,11 +107,21 @@
 	</form>
 
 	<p class="instant-content-terms">
-		<?php printf(
-		__( '<a href="%s">Instant Content Support</a>', 'instant-content' ), esc_url( 'http://www.instantcontent.me/contact' ) ); ?>
+		<?php
+		printf(
+			'<a href="%s">%s</a>',
+			esc_url( 'http://www.instantcontent.me/contact' ),
+			__( 'Instant Content Support', 'instant-content' )
+		);
+		?>
 		<span> | </span>
-		<?php printf(
-		__( '<a class="thickbox" href="%s">Instant Content Terms and Conditions</a>', 'instant-content' ), esc_url( plugins_url( 'service-license.html?width=800', __FILE__ ) ) ); ?>
+		<?php
+		printf(
+			'<a href="%s" class="thickbox">%s</a>',
+			esc_url( plugins_url( 'service-license.html?width=800', __FILE__ ) ),
+			__( 'Instant Content Terms and Conditions', 'instant-content' )
+		);
+		?>
 	</p>
 
 </div>


### PR DESCRIPTION
While basic markup (including links) inside internationalised strings is fine when it avoids splitting strings up, there's little point in having markup around the outside of the string, since it can just be moved outside.
